### PR TITLE
Update name field in gbc.json

### DIFF
--- a/pkg/pocket/Platforms/gbc.json
+++ b/pkg/pocket/Platforms/gbc.json
@@ -1,7 +1,7 @@
 {
   "platform": {
     "category": "Handheld",
-    "name": "GBC",
+    "name": "Game Boy Color",
     "manufacturer": "Nintendo",
     "year": 1998
   }


### PR DESCRIPTION
Sorry for the pedantic PR. A suggestion to change the `name` field in `gbc.json` to match it back to what spiritualized1997's core (plus the other cores have gone for the long form names of game devices).