### PR TITLE
Add Fastforward option

### DIFF
--- a/pkg/gb/Cores/budude2.GB/interact.json
+++ b/pkg/gb/Cores/budude2.GB/interact.json
@@ -23,11 +23,23 @@
         "value_off": 0
       },
       {
-        "name": "Enable FF Sound",
+        "name": "Enable FF",
         "id": 14,
         "type": "check",
         "enabled": true,
         "address": "0x20C",
+        "persist": true,
+        "writeonly": true,
+        "defaultval": 1,
+        "value": 1,
+        "value_off": 0
+      },
+      {
+        "name": "Enable FF Sound",
+        "id": 15,
+        "type": "check",
+        "enabled": true,
+        "address": "0x210",
         "persist": true,
         "writeonly": true,
         "defaultval": 0,

--- a/pkg/gbc/Cores/budude2.GBC/interact.json
+++ b/pkg/gbc/Cores/budude2.GBC/interact.json
@@ -35,11 +35,23 @@
         "value_off": 0
       },
       {
-        "name": "Enable FF Sound",
+        "name": "Enable FF",
         "id": 14,
         "type": "check",
         "enabled": true,
         "address": "0x20C",
+        "persist": true,
+        "writeonly": true,
+        "defaultval": 1,
+        "value": 1,
+        "value_off": 0
+      },
+      {
+        "name": "Enable FF Sound",
+        "id": 15,
+        "type": "check",
+        "enabled": true,
+        "address": "0x210",
         "persist": true,
         "writeonly": true,
         "defaultval": 0,

--- a/src/core/core_top.sv
+++ b/src/core/core_top.sv
@@ -306,6 +306,7 @@ end
 
 reg [31:0] reset_delay  = 0;
 reg rumble_en           = 0;
+reg ff_en               = 0;
 reg ff_snd_en           = 0;
 reg [1:0] tint          = 0;
 reg originalcolors;
@@ -330,10 +331,13 @@ always @(posedge clk_74a) begin
         32'h208: begin
           originalcolors <= bridge_wr_data[0];
         end
-        32'h20C: begin
-          ff_snd_en <= bridge_wr_data[0];
+		32'h20C: begin
+          ff_en <= bridge_wr_data[0];
         end
         32'h210: begin
+          ff_snd_en <= bridge_wr_data[0];
+        end
+        32'h214: begin
           tint <= bridge_wr_data[1:0];
         end
       endcase
@@ -1148,7 +1152,7 @@ sgb sgb (
 wire ce_cpu, ce_cpu2x;
 wire cart_act = cart_wr | cart_rd;
 
-wire fastforward = cont1_key_s[9] && !ioctl_download;
+wire fastforward = ff_en && cont1_key_s[9] && !ioctl_download;
 wire ff_on;
 
 wire sleep_savestate;


### PR DESCRIPTION
I have also been wanting #24 and tried it myself. I could not figure out what is in the bridge part that is read into `tint`, so I assumed it must be unused empty data and it is fine to move it. I compiled and tested it and everything works fine.